### PR TITLE
Minor language change suggestion #177

### DIFF
--- a/dabl/models.py
+++ b/dabl/models.py
@@ -419,7 +419,7 @@ class AnyClassifier(_DablBaseEstimator, ClassifierMixin):
         if ((y is None and target_col is None)
                 or (y is not None) and (target_col is not None)):
             raise ValueError(
-                "Need to specify exactly one of y and target_col.")
+                "Need to specify either y or target_col.")
         X, y = _validate_Xyt(X, y, target_col, do_clean=False)
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)

--- a/dabl/plot/supervised.py
+++ b/dabl/plot/supervised.py
@@ -519,7 +519,7 @@ def plot(X, y=None, target_col=None, type_hints=None, scatter_alpha='auto',
     if ((y is None and target_col is None)
             or (y is not None) and (target_col is not None)):
         raise ValueError(
-            "Need to specify exactly one of y and target_col.")
+            "Need to specify either y or target_col.")
     if isinstance(y, str):
         warnings.warn("The second positional argument of plot is a Series 'y'."
                       " If passing a column name, use a keyword.",

--- a/dabl/utils.py
+++ b/dabl/utils.py
@@ -32,7 +32,7 @@ def _validate_Xyt(X, y, target_col, do_clean=True):
     if ((y is None and target_col is None)
             or (y is not None) and (target_col is not None)):
         raise ValueError(
-            "Need to specify exactly one of y and target_col.")
+            "Need to specify either y or target_col.")
     if do_clean:
         X = clean(X)
     if target_col is not None:


### PR DESCRIPTION
Updated `"Need to specify exactly one of y and target_col."` to `"Need to specify either y or target_col."`. 

Use of `either-or` clause clears the confusion which existed in the previous statement.  